### PR TITLE
Fix etherscan ens lookup link

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -98,7 +98,7 @@ Check out the following places for more viem-related content:
 
 - [GitHub Sponsors](https://github.com/sponsors/wevm?metadata_campaign=docs_support)
 - [Gitcoin Grant](https://wagmi.sh/gitcoin)
-- [wevm.eth](https://etherscan.io/enslookup-search?search=wevm.eth)
+- [wevm.eth](https://etherscan.io/name-lookup-search?id=wevm.eth)
 
 ## Sponsors
 


### PR DESCRIPTION
Etherscan changed their lookup link and current link was throwing an error